### PR TITLE
Prevent CONDA_PREFIX from leaking into subprocesses

### DIFF
--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -21,9 +21,9 @@ if not defined CARGO_BUILD_TARGET (
 REM Use cargo install with explicit target for cross-compilation (this needed, otherwise linking errors occurs)
 if defined CARGO_BUILD_TARGET (
     echo Building for target: %CARGO_BUILD_TARGET%
-    cargo install --locked --no-track --bins --root "%PREFIX%" --path cli --target %CARGO_BUILD_TARGET%
+    cargo auditable install --locked --no-track --bins --root "%PREFIX%" --path cli --target %CARGO_BUILD_TARGET%
 ) else (
-    cargo install --locked --no-track --bins --root "%PREFIX%" --path cli
+    cargo auditable install --locked --no-track --bins --root "%PREFIX%" --path cli
 )
 
 REM Pixi: prevent CONDA_PREFIX from leaking into sandboxed processes
@@ -32,25 +32,6 @@ if not exist "%MARKER_DIR%" (
     mkdir "%MARKER_DIR%" 2>nul
 )
 type nul > "%MARKER_DIR%\global-ignore-conda-prefix"
-
-REM Recreate Node-style layout so the Node wrapper can locate platform-tagged binaries
-set "EXPECTED_DIR=%PREFIX%\lib\node_modules\@openai\codex\bin"
-set "ACTUAL_BIN=%PREFIX%\bin\codex.exe"
-
-if not exist "%EXPECTED_DIR%" (
-    mkdir "%EXPECTED_DIR%" 2>nul
-)
-
-if exist "%ACTUAL_BIN%" (
-    for %%N in ( 
-        codex-x86_64-pc-windows-msvc.exe 
-        codex-aarch64-pc-windows-msvc.exe 
-    ) do (
-        if not exist "%EXPECTED_DIR%\%%N" (
-            copy /Y "%ACTUAL_BIN" "%EXPECTED_DIR%\%%N" >nul
-        )
-    )
-)
 
 endlocal
 exit /b 0

--- a/recipe/build.bat
+++ b/recipe/build.bat
@@ -26,6 +26,13 @@ if defined CARGO_BUILD_TARGET (
     cargo install --locked --no-track --bins --root "%PREFIX%" --path cli
 )
 
+REM Pixi: prevent CONDA_PREFIX from leaking into sandboxed processes
+set "MARKER_DIR=%PREFIX%\etc\pixi\codex"
+if not exist "%MARKER_DIR%" (
+    mkdir "%MARKER_DIR%" 2>nul
+)
+type nul > "%MARKER_DIR%\global-ignore-conda-prefix"
+
 REM Recreate Node-style layout so the Node wrapper can locate platform-tagged binaries
 set "EXPECTED_DIR=%PREFIX%\lib\node_modules\@openai\codex\bin"
 set "ACTUAL_BIN=%PREFIX%\bin\codex.exe"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -29,6 +29,10 @@ else
     cargo install --locked --no-track --bins --root "${PREFIX}" --path cli
 fi
 
+# Pixi: prevent CONDA_PREFIX from leaking into sandboxed processes
+mkdir -p "${PREFIX}/etc/pixi/codex"
+touch "${PREFIX}/etc/pixi/codex/global-ignore-conda-prefix"
+
 # Recreate Node-style layout so the JS wrapper can locate platform-tagged binaries without a post-link script
 EXPECTED_DIR="${PREFIX}/lib/node_modules/@openai/codex/bin"
 ACTUAL_BIN="${PREFIX}/bin/codex"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,38 +24,11 @@ cargo-bundle-licenses --format yaml --output ../THIRDPARTY.yml
 # Use cargo install with explicit target for cross-compilation (this is needed, otherwise linking fails)
 if [ -n "${CARGO_BUILD_TARGET:-}" ]; then
     echo "Building for target: ${CARGO_BUILD_TARGET}"
-    cargo install --locked --no-track --bins --root "${PREFIX}" --path cli --target "${CARGO_BUILD_TARGET}"
+    cargo auditable install --locked --no-track --bins --root "${PREFIX}" --path cli --target "${CARGO_BUILD_TARGET}"
 else
-    cargo install --locked --no-track --bins --root "${PREFIX}" --path cli
+    cargo auditable install --locked --no-track --bins --root "${PREFIX}" --path cli
 fi
 
 # Pixi: prevent CONDA_PREFIX from leaking into sandboxed processes
 mkdir -p "${PREFIX}/etc/pixi/codex"
 touch "${PREFIX}/etc/pixi/codex/global-ignore-conda-prefix"
-
-# Recreate Node-style layout so the JS wrapper can locate platform-tagged binaries without a post-link script
-EXPECTED_DIR="${PREFIX}/lib/node_modules/@openai/codex/bin"
-ACTUAL_BIN="${PREFIX}/bin/codex"
-mkdir -p "${EXPECTED_DIR}"
-
-if [ -x "${ACTUAL_BIN}" ]; then
-    NAMES=(
-        codex-aarch64-apple-darwin
-        codex-x86_64-apple-darwin
-        codex-aarch64-unknown-linux-gnu
-        codex-x86_64-unknown-linux-gnu
-        codex-aarch64-unknown-linux-musl
-        codex-x86_64-unknown-linux-musl
-    )
-    for name in "${NAMES[@]}"; do
-        target="${EXPECTED_DIR}/${name}"
-        if [ -e "${target}" ]; then
-            continue
-        fi
-        if ln -sfn "${ACTUAL_BIN}" "${target}" 2>/dev/null; then
-            :
-        else
-            cp -f "${ACTUAL_BIN}" "${target}"
-        fi
-    done
-fi

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,9 +1,8 @@
 context:
-  name: codex
   version: "0.142.5"
 
 package:
-  name: ${{ name|lower }}
+  name: codex
   version: ${{ version }}
 
 source:
@@ -20,6 +19,7 @@ requirements:
     - ${{ compiler('cxx') }}
     - ${{ stdlib('c') }}
     - cargo-bundle-licenses
+    - cargo-auditable
     - pkg-config
     - openssl
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -36,12 +36,7 @@ tests:
       - codex --version
   - package_contents:
       bin:
-        - if: unix
-          then:
-            - codex
-        - if: win
-          then:
-            - codex.exe
+        - codex
       files:
         - etc/pixi/codex/global-ignore-conda-prefix
       strict: true

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
   sha256: c877887e3cf0d1435552b4ef3516023244f92320da9d1fe142f5a8d03bcd7a95
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -36,7 +36,15 @@ tests:
       - codex --version
   - package_contents:
       bin:
-        - codex
+        - if: unix
+          then:
+            - codex
+        - if: win
+          then:
+            - codex.exe
+      files:
+        - etc/pixi/codex/global-ignore-conda-prefix
+      strict: true
 
 about:
   summary: Lightweight coding agent that runs in your terminal


### PR DESCRIPTION
Add Pixi marker file to signal that codex does not need conda environment variables leaking into processes it spawns.

Reference: https://github.com/conda-forge/bubblewrap-feedstock/pull/19